### PR TITLE
feat: enhance task_started event handling in Roquefort class

### DIFF
--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -178,7 +178,8 @@ class Roquefort:
                         # Timeout is expected, just continue
                         continue
                     except (KeyboardInterrupt, SystemExit):
-                        logging.info("Shutdown signal received in metrics collection")
+                        logging.info(
+                            "Shutdown signal received in metrics collection")
                         self._shutdown_event.set()
                         raise
                     except Exception as e:
@@ -188,7 +189,8 @@ class Roquefort:
                         await asyncio.sleep(1)
 
         except (KeyboardInterrupt, SystemExit):
-            logging.info("Shutdown signal received, stopping metrics collection")
+            logging.info(
+                "Shutdown signal received, stopping metrics collection")
             self._shutdown_event.set()
         except Exception as e:
             if not self._shutdown_event.is_set():

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -178,8 +178,7 @@ class Roquefort:
                         # Timeout is expected, just continue
                         continue
                     except (KeyboardInterrupt, SystemExit):
-                        logging.info(
-                            "Shutdown signal received in metrics collection")
+                        logging.info("Shutdown signal received in metrics collection")
                         self._shutdown_event.set()
                         raise
                     except Exception as e:
@@ -189,8 +188,7 @@ class Roquefort:
                         await asyncio.sleep(1)
 
         except (KeyboardInterrupt, SystemExit):
-            logging.info(
-                "Shutdown signal received, stopping metrics collection")
+            logging.info("Shutdown signal received, stopping metrics collection")
             self._shutdown_event.set()
         except Exception as e:
             if not self._shutdown_event.is_set():

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -20,11 +20,14 @@ class HttpServer:
         self._host = host
         self._port = port
         self._registry = registry
+        self._server_started = False
 
     async def run(self):
-        logging.info(f"Starting HTTP server on {self._host}:{self._port}")
-        start_http_server(addr=self._host, port=self._port, registry=self._registry)
-        logging.info(f"HTTP server started on {self._host}:{self._port}")
+        if not self._server_started:
+            logging.info(f"Starting HTTP server on {self._host}:{self._port}")
+            start_http_server(addr=self._host, port=self._port, registry=self._registry)
+            logging.info(f"HTTP server started on {self._host}:{self._port}")
+            self._server_started = True
         await asyncio.sleep(1)
 
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -20,14 +20,11 @@ class HttpServer:
         self._host = host
         self._port = port
         self._registry = registry
-        self._server_started = False
 
     async def run(self):
-        if not self._server_started:
-            logging.info(f"Starting HTTP server on {self._host}:{self._port}")
-            start_http_server(addr=self._host, port=self._port, registry=self._registry)
-            logging.info(f"HTTP server started on {self._host}:{self._port}")
-            self._server_started = True
+        logging.info(f"Starting HTTP server on {self._host}:{self._port}")
+        start_http_server(addr=self._host, port=self._port, registry=self._registry)
+        logging.info(f"HTTP server started on {self._host}:{self._port}")
         await asyncio.sleep(1)
 
 


### PR DESCRIPTION
- Updated the `_handle_task_started` method to include detailed task information and worker details.
- Modified the metric labels to include the worker name, improving the granularity of metrics.
- Ensured the retrieval of the queue name is more robust by utilizing task attributes and worker metadata.

This pull request updates task metrics handling in `src/roquefort.py` to improve tracking and debugging. The key changes include adding a new `worker` label to task metrics, re-enabling the `task-started` handler, and enhancing the `_handle_task_started` method for better event processing and debugging.

### Metrics enhancements:

* Updated the `task_started` metric to include a new `worker` label, improving granularity in task tracking. (`[src/roquefort.pyL58-R58](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L58-R58)`)

### Task handler updates:

* Re-enabled the `task-started` handler in the `update_metrics` method, allowing the system to process `task-started` events again. (`[src/roquefort.pyL135-R135](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L135-R135)`)

### Debugging and processing improvements:

* Enhanced the `_handle_task_started` method by:
  * Adding detailed debugging with `pprint` for both the event and the task's attributes.
  * Introducing logic to extract the `worker` name and determine the `queue_name` more robustly using task metadata or defaults.
  * Refactoring the method to use the new `worker` label in task metrics. (`[src/roquefort.pyR283-R305](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R283-R305)`)