### PR TITLE
feat: enable metrics for task retried

### DIFF
--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -137,7 +137,7 @@ class Roquefort:
             "task-started": self._handle_task_started,
             "task-succeeded": self._handle_task_succeeded,
             "task-failed": self._handle_task_failed,
-            # "task-retried": self._handle_task_retried,
+            "task-retried": self._handle_task_retried,
             # "task-rejected": self._handle_task_rejected,
             # "task-revoked": self._handle_task_revoked,
             "worker-heartbeat": self._handle_worker_heartbeat,

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -401,19 +401,19 @@ class Roquefort:
 
     def _handle_task_failed(self, event):
         task = self._get_task_from_event(event)
-        
+
         hostname = event.get("hostname")
         worker_name, _ = get_worker_names(hostname)
-        
+
         queue_name = (
             getattr(task, "queue")
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )
-        
+
         exception = getattr(task, "exception", None) or event.get("exception")
         exception_name = get_exception_name(exception)
-        
+
         self._handle_task_generic(
             event=event,
             task=task,
@@ -428,13 +428,30 @@ class Roquefort:
         )
 
     def _handle_task_retried(self, event):
+        task = self._get_task_from_event(event)
+
+        hostname = event.get("hostname")
+        worker_name, _ = get_worker_names(hostname)
+
+        queue_name = (
+            getattr(task, "queue")
+            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
+            or self._default_queue_name
+        )
+
+        exception = getattr(task, "exception", None) or event.get("exception")
+        exception_name = get_exception_name(exception)
+
         self._handle_task_generic(
-            event,
-            "task_retried",
-            {
-                "name": event.get("name", "unknown"),
-                "hostname": event.get("hostname", "unknown"),
-                "queue_name": event.get("queue", "unknown"),
+            event=event,
+            task=task,
+            metric_name="task_retried",
+            labels={
+                "name": getattr(task, "name"),
+                "worker": worker_name,
+                "hostname": hostname,
+                "queue_name": queue_name,
+                "exception": exception_name,
             },
         )
 

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -72,7 +72,7 @@ class Roquefort:
         self._metrics.create_counter(
             "task_retried",
             "Sent if the task was retried.",
-            labels=["name","worker", "hostname", "queue_name", "exception"],
+            labels=["name", "worker", "hostname", "queue_name", "exception"],
         )
         self._metrics.create_counter(
             "task_rejected",

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -72,7 +72,7 @@ class Roquefort:
         self._metrics.create_counter(
             "task_retried",
             "Sent if the task was retried.",
-            labels=["name", "hostname", "queue_name", "exception"],
+            labels=["name","worker", "hostname", "queue_name", "exception"],
         )
         self._metrics.create_counter(
             "task_rejected",


### PR DESCRIPTION
This pull request enhances the task retry metrics in `src/roquefort.py` by adding a new "worker" label, re-enabling the handling of retried tasks, and improving the `_handle_task_retried` method for more accurate metric reporting.

### Metrics Improvements:

* Updated the `task_retried` metric to include a new "worker" label for better granularity in tracking task retries. (`src/roquefort.py`, [src/roquefort.pyL75-R75](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L75-R75))

### Functional Enhancements:

* Re-enabled the handling of "task-retried" events in the `update_metrics` method, which had previously been commented out, ensuring these events are now processed. (`src/roquefort.py`, [src/roquefort.pyL140-R140](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L140-R140))

* Refactored the `_handle_task_retried` method to:
  - Extract task details from the event more robustly.
  - Derive the worker name and queue name dynamically using helper functions and metadata.
  - Retrieve and normalize exception information for the metric labels.
  These changes improve the accuracy and usefulness of the "task_retried" metric. (`src/roquefort.py`, [src/roquefort.pyR431-R454](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R431-R454))