### PR TITLE
feat: enable metrics for task revoked and rejected

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -2,6 +2,7 @@ import logging
 import re
 from celery.utils import nodesplit  # type: ignore
 
+
 def format_queue_names(queue_names: list[str]) -> str:
     """Format a list of queue names into a string.
 
@@ -22,6 +23,7 @@ def get_worker_names(name: str) -> tuple[str, str]:
         return "unknown", "unknown"
     return workername, hostname
 
+
 def get_queue_name_from_worker_metadata(worker: str, metadata: dict) -> str:
     """Get the queue name from the worker metadata.
 
@@ -32,22 +34,24 @@ def get_queue_name_from_worker_metadata(worker: str, metadata: dict) -> str:
     if worker not in metadata:
         logging.warning(f"worker {worker} not found in metadata")
         return None
-    
+
     worker_metadata = metadata.get(worker, {})
-    
+
     if not "queues" in worker_metadata:
         logging.warning(f"queues not found in worker metadata for {worker}")
         return None
-    
+
     queues = worker_metadata.get("queues", [])
-    
+
     if len(queues) != 1:
         logging.warning(f"multiple queues found for {worker}: {queues}")
         return None
 
     return queues[0]
 
+
 exception_re = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\(")
+
 
 def get_exception_name(message: str) -> str:
     match = exception_re.match(message)

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -518,6 +518,7 @@ class Roquefort:
         self._state.event(event)
         return self._state.tasks.get(event.get("uuid"))
 
+
 async def main():
     roquefort = Roquefort(
         broker_url="redis://localhost:6379/0",

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -82,7 +82,7 @@ class Roquefort:
         self._metrics.create_counter(
             "task_revoked",
             "Sent if the task was revoked.",
-            labels=["name", "hostname", "queue_name", "exception"],
+            labels=["name", "worker", "hostname", "queue_name"],
         )
         #   Gauges
         self._metrics.create_gauge(

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -189,7 +189,7 @@ class Roquefort:
                         if self._shutdown_event.is_set():
                             break
                         logging.exception(f"Error in update_metrics: {e}")
-                    
+
                     await asyncio.sleep(1)
 
         except (KeyboardInterrupt, SystemExit):
@@ -457,16 +457,16 @@ class Roquefort:
 
     def _handle_task_rejected(self, event):
         task = self._get_task_from_event(event)
-        
+
         hostname = event.get("hostname")
         worker_name, _ = get_worker_names(hostname)
-        
+
         queue_name = (
             getattr(task, "queue")
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )
-        
+
         self._handle_task_generic(
             event=event,
             task=task,
@@ -517,9 +517,6 @@ class Roquefort:
     def _get_task_from_event(self, event) -> Task:
         self._state.event(event)
         return self._state.tasks.get(event.get("uuid"))
-
-        # todo: add metrics handling for active processes.
-        # todo: add metrics handling for processed tasks.
 
 async def main():
     roquefort = Roquefort(

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -480,13 +480,26 @@ class Roquefort:
         )
 
     def _handle_task_revoked(self, event):
+        task = self._get_task_from_event(event)
+
+        hostname = event.get("hostname")
+        worker_name, _ = get_worker_names(hostname)
+
+        queue_name = (
+            getattr(task, "queue")
+            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
+            or self._default_queue_name
+        )
+
         self._handle_task_generic(
-            event,
-            "task_revoked",
-            {
-                "name": event.get("name", "unknown"),
-                "hostname": event.get("hostname", "unknown"),
-                "queue_name": event.get("queue", "unknown"),
+            event=event,
+            task=task,
+            metric_name="task_revoked",
+            labels={
+                "name": getattr(task, "name"),
+                "worker": worker_name,
+                "hostname": hostname,
+                "queue_name": queue_name,
             },
         )
 

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -138,7 +138,7 @@ class Roquefort:
             "task-succeeded": self._handle_task_succeeded,
             "task-failed": self._handle_task_failed,
             "task-retried": self._handle_task_retried,
-            # "task-rejected": self._handle_task_rejected,
+            "task-rejected": self._handle_task_rejected,
             # "task-revoked": self._handle_task_revoked,
             "worker-heartbeat": self._handle_worker_heartbeat,
             # "worker-online": self._handle_worker_online,

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -77,7 +77,7 @@ class Roquefort:
         self._metrics.create_counter(
             "task_rejected",
             "Sent if the task was rejected.",
-            labels=["name", "hostname", "queue_name", "exception"],
+            labels=["name", "worker", "hostname", "queue_name"],
         )
         self._metrics.create_counter(
             "task_revoked",

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -139,7 +139,7 @@ class Roquefort:
             "task-failed": self._handle_task_failed,
             "task-retried": self._handle_task_retried,
             "task-rejected": self._handle_task_rejected,
-            # "task-revoked": self._handle_task_revoked,
+            "task-revoked": self._handle_task_revoked,
             "worker-heartbeat": self._handle_worker_heartbeat,
             # "worker-online": self._handle_worker_online,
             # "worker-offline": self._handle_worker_offline,
@@ -173,7 +173,6 @@ class Roquefort:
                 while not self._shutdown_event.is_set():
                     try:
                         logging.debug("updating metrics")
-                        logging.debug("updating metrics")
                         # Use run_in_executor to avoid blocking the event loop
                         await loop.run_in_executor(
                             None,
@@ -190,7 +189,8 @@ class Roquefort:
                         if self._shutdown_event.is_set():
                             break
                         logging.exception(f"Error in update_metrics: {e}")
-                        await asyncio.sleep(1)
+                    
+                    await asyncio.sleep(1)
 
         except (KeyboardInterrupt, SystemExit):
             logging.info("Shutdown signal received, stopping metrics collection")

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -456,13 +456,26 @@ class Roquefort:
         )
 
     def _handle_task_rejected(self, event):
+        task = self._get_task_from_event(event)
+        
+        hostname = event.get("hostname")
+        worker_name, _ = get_worker_names(hostname)
+        
+        queue_name = (
+            getattr(task, "queue")
+            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
+            or self._default_queue_name
+        )
+        
         self._handle_task_generic(
-            event,
-            "task_rejected",
-            {
-                "name": event.get("name", "unknown"),
-                "hostname": event.get("hostname", "unknown"),
-                "queue_name": event.get("queue", "unknown"),
+            event=event,
+            task=task,
+            metric_name="task_rejected",
+            labels={
+                "name": getattr(task, "name"),
+                "worker": worker_name,
+                "hostname": hostname,
+                "queue_name": queue_name,
             },
         )
 


### PR DESCRIPTION
This pull request updates the `src/roquefort.py` file to enhance task metrics handling by adding new labels, re-enabling certain metrics, and improving the logic for rejected and revoked tasks. It also includes minor cleanups and fixes.

### Enhancements to Metrics Handling:

* Updated the `task_rejected` and `task_revoked` counters to include a new `worker` label, replacing the `exception` label for better granularity in metrics. (`[src/roquefort.pyL80-R85](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L80-R85)`)
* Re-enabled the handling of `task-rejected` and `task-revoked` events in the `update_metrics` method, ensuring these metrics are now actively processed. (`[src/roquefort.pyL141-R142](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L141-R142)`)
* Refactored `_handle_task_rejected` and `_handle_task_revoked` methods to extract additional information (e.g., `worker` and `queue_name`) and pass it as labels to the metrics. (`[src/roquefort.pyR459-R502](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R459-R502)`)

### Minor Fixes and Cleanups:

* Removed redundant debug logging in the `update_metrics` method. (`[src/roquefort.pyL175](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L175)`)
* Eliminated an unnecessary empty line in the exception handling block of `update_metrics`. (`[src/roquefort.pyR192](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R192)`)
* Cleaned up outdated comments in `_get_task_from_event`. (`[src/roquefort.pyL508-L509](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L508-L509)`)