### PR TITLE
feat: enable metrics for worker online/offline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN adduser \
     --uid "${UID}" \
     appuser
 
+# Create cache directory for appuser and set permissions
+RUN mkdir -p /home/appuser/.cache && chown -R appuser:appuser /home/appuser/.cache
+
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
 # Leverage a bind mount to requirements.txt to avoid having to copy them into
@@ -39,11 +42,14 @@ RUN pip install uv
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=README.md,target=README.md \
     uv sync
 
-# Create cache directory for appuser and set permissions
-RUN mkdir -p /home/appuser/.cache && chown -R appuser:appuser /home/appuser/.cache
-
+    
+CMD ["uv", "run", "python", "--version"]
+    
+FROM base AS app
+    
 # Switch to the non-privileged user to run the application.
 USER appuser
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+IMAGE_REGISTRY = ghcr.io/freepik-company
+IMAGE_NAME = $(IMAGE_REGISTRY)/celery-roquefort
+
 .PHONY: help setup install dev run docker-build docker-run clean
 
 # Default target
@@ -60,3 +63,11 @@ git-prune: ## Prune the git repository
 		echo "No branches were selected for deletion."; \
 	fi
 	@rm .branches_to_delete
+
+docker-build: docker-build-base docker-build-app
+
+docker-build-base:
+	docker build -t $(IMAGE_NAME):base -f Dockerfile .
+
+docker-build-app:
+	docker build -t $(IMAGE_NAME):dev -f Dockerfile .

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -1,6 +1,6 @@
+# roquefort.py
 import asyncio
 import logging
-from pprint import pp, pformat, pprint
 import socket
 from celery import Celery, Task
 from fastapi import FastAPI
@@ -17,7 +17,6 @@ from .server.server import HttpServer
 
 
 class Roquefort:
-
     def __init__(
         self,
         broker_url: str,
@@ -28,142 +27,80 @@ class Roquefort:
         default_queue_name: str = None,
     ) -> None:
         self._broker_url = broker_url
-        self._metrics: MetricService = MetricService(
-            metric_prefix=prefix, custom_labels=custom_labels
-        )
-        self._server: HttpServer = HttpServer(
-            host=host, port=port, registry=self._metrics.get_registry()
-        )
-        self._app: Celery = None
-        self._state: Celery.events.State = None
+        self._metrics = MetricService(metric_prefix=prefix, custom_labels=custom_labels)
+        self._server = HttpServer(host=host, port=port, registry=self._metrics.get_registry())
+        self._app = None
+        self._state = None
         self._shutdown_event = asyncio.Event()
         self._server_started = False
         self._workers_metadata = {}
-        self._tracked_events = []
         self._default_queue_name = default_queue_name
 
-        # Create metrics
-        #   Counters
-        self._metrics.create_counter(
-            "task_sent",
-            "Sent when a task message is published.",
-            labels=["name", "hostname", "queue_name"],
-        )
-        self._metrics.create_counter(
-            "task_received",
-            "Received when a task message is received.",
-            labels=["name", "worker", "hostname", "queue_name"],
-        )
-        self._metrics.create_counter(
-            "task_started",
-            "Sent just before a worker runs a task.",
-            labels=["name", "worker", "hostname", "queue_name"],
-        )
-        self._metrics.create_counter(
-            "task_succeeded",
-            "Sent if the task was executed successfully.",
-            labels=["name", "worker", "hostname", "queue_name"],
-        )
-        self._metrics.create_counter(
-            "task_failed",
-            "Sent if the task failed.",
-            labels=["name", "worker", "hostname", "queue_name", "exception"],
-        )
-        self._metrics.create_counter(
-            "task_retried",
-            "Sent if the task was retried.",
-            labels=["name", "worker", "hostname", "queue_name", "exception"],
-        )
-        self._metrics.create_counter(
-            "task_rejected",
-            "Sent if the task was rejected.",
-            labels=["name", "worker", "hostname", "queue_name"],
-        )
-        self._metrics.create_counter(
-            "task_revoked",
-            "Sent if the task was revoked.",
-            labels=["name", "worker", "hostname", "queue_name"],
-        )
-        #   Gauges
-        self._metrics.create_gauge(
-            "worker_active",
-            "Number of active workers. It indicates that the worker has recently sent a heartbeat.",
-            labels=["hostname", "worker", "queue_name"],
-        )
-        self._metrics.create_gauge(
-            "worker_tasks_active",
-            "Number of tasks currently being processed by the workers.",
-            labels=["hostname", "queue_name"],
-        )
-        self._metrics.create_gauge(
-            "queue_length", "Number of tasks in the queue.", labels=["queue_name"]
-        )
-        self._metrics.create_gauge(
-            "active_consumer_count",
-            "The number of active consumer in broker queue.",
-            labels=["queue_name"],
-        )
-        self._metrics.create_gauge(
-            "active_worker_count",
-            "The number of active workers in broker queue.",
-            labels=["queue_name"],
-        )
-        self._metrics.create_gauge(
-            "active_process_count",
-            "The number of active processes in broker queue.",
-            labels=["queue_name"],
-        )
-        #   Histograms
-        self._metrics.create_histogram(
-            "task_runtime",
-            "Histogram of task runtime measurements.",
-            labels=["name", "hostname", "queue_name"],
-        )
+        self._tracked_events = [
+            "task-sent", "task-received", "task-started", "task-succeeded", "task-failed",
+            "task-retried", "task-rejected", "task-revoked",
+            "worker-heartbeat", "worker-online", "worker-offline"
+        ]
+
+        self._create_metrics()
 
     def _lifespan(self):
         async def lifespan(app: FastAPI):
             asyncio.create_task(self.update_metrics())
             yield
-
         return lifespan
+
+    def _create_metrics(self):
+        counters = [
+            ("task_sent", "Sent when a task message is published.", ["name", "hostname", "queue_name"]),
+            ("task_received", "Received when a task message is received.", ["name", "worker", "hostname", "queue_name"]),
+            ("task_started", "Sent just before a worker runs a task.", ["name", "worker", "hostname", "queue_name"]),
+            ("task_succeeded", "Sent if the task was executed successfully.", ["name", "worker", "hostname", "queue_name"]),
+            ("task_failed", "Sent if the task failed.", ["name", "worker", "hostname", "queue_name", "exception"]),
+            ("task_retried", "Sent if the task was retried.", ["name", "worker", "hostname", "queue_name", "exception"]),
+            ("task_rejected", "Sent if the task was rejected.", ["name", "worker", "hostname", "queue_name"]),
+            ("task_revoked", "Sent if the task was revoked.", ["name", "worker", "hostname", "queue_name"]),
+        ]
+
+        gauges = [
+            ("worker_active", "Number of active workers.", ["hostname", "worker", "queue_name"]),
+            ("worker_tasks_active", "Number of tasks currently being processed by workers.", ["hostname", "queue_name"]),
+            ("queue_length", "Number of tasks in the queue.", ["queue_name"]),
+            ("active_consumer_count", "Number of active consumers in broker queue.", ["queue_name"]),
+            ("active_worker_count", "Number of active workers in broker queue.", ["queue_name"]),
+            ("active_process_count", "Number of active processes in broker queue.", ["queue_name"]),
+        ]
+
+        for name, desc, labels in counters:
+            self._metrics.create_counter(name, desc, labels)
+
+        for name, desc, labels in gauges:
+            self._metrics.create_gauge(name, desc, labels)
+
+        self._metrics.create_histogram(
+            "task_runtime", "Histogram of task runtime measurements.", ["name", "hostname", "queue_name"]
+        )
 
     async def update_metrics(self):
         logging.info("starting metrics collection")
         self._app = Celery(broker=self._broker_url)
         self._state = self._app.events.State()
+
+        self._update_worker_metadata()
+
         handlers = {
-            # "task-sent": self._handle_task_sent,
-            # "task-received": self._handle_task_received,
-            # "task-started": self._handle_task_started,
-            # "task-succeeded": self._handle_task_succeeded,
-            # "task-failed": self._handle_task_failed,
-            # "task-retried": self._handle_task_retried,
-            # "task-rejected": self._handle_task_rejected,
-            # "task-revoked": self._handle_task_revoked,
-            # "worker-heartbeat": self._handle_worker_heartbeat,
+            "task-sent": self._handle_task_sent,
+            "task-received": self._handle_task_received,
+            "task-started": self._handle_task_started,
+            "task-succeeded": self._handle_task_succeeded,
+            "task-failed": self._handle_task_failed,
+            "task-retried": self._handle_task_retried,
+            "task-rejected": self._handle_task_rejected,
+            "task-revoked": self._handle_task_revoked,
+            "worker-heartbeat": self._handle_worker_heartbeat,
             "worker-online": self._handle_worker_status,
             "worker-offline": self._handle_worker_status,
         }
-
-        self._tracked_events = list(handlers.keys())
-
-        self._tracked_events = list(handlers.keys())
-
-        # Load queue info
-        queues = self._get_active_queues()
-
-        for worker_name, queue_info_list in queues.items():
-            if worker_name not in self._workers_metadata:
-                self._workers_metadata[worker_name] = {"queues": []}
-
-            for queue_info in queue_info_list:
-                queue_name = queue_info.get("name")
-
-                if not queue_name:
-                    continue
-
-                if queue_name not in self._workers_metadata[worker_name]["queues"]:
-                    self._workers_metadata[worker_name]["queues"].append(queue_name)
 
         try:
             with self._app.connection() as connection:
@@ -172,412 +109,127 @@ class Roquefort:
 
                 while not self._shutdown_event.is_set():
                     try:
-                        logging.debug("updating metrics")
-                        # Use run_in_executor to avoid blocking the event loop
-                        await loop.run_in_executor(
-                            None,
-                            lambda: recv.capture(limit=None, timeout=1, wakeup=True),
-                        )
+                        await loop.run_in_executor(None, lambda: recv.capture(limit=None, timeout=1, wakeup=True))
                     except socket.timeout:
-                        # Timeout is expected, just continue
                         continue
                     except (KeyboardInterrupt, SystemExit):
-                        logging.info("Shutdown signal received in metrics collection")
                         self._shutdown_event.set()
                         raise
                     except Exception as e:
-                        if self._shutdown_event.is_set():
-                            break
-                        logging.exception(f"Error in update_metrics: {e}")
-
+                        if not self._shutdown_event.is_set():
+                            logging.exception(f"Error in update_metrics: {e}")
                     await asyncio.sleep(1)
-
-        except (KeyboardInterrupt, SystemExit):
-            logging.info("Shutdown signal received, stopping metrics collection")
-            self._shutdown_event.set()
-        except Exception as e:
-            if not self._shutdown_event.is_set():
-                logging.exception(f"Fatal error in update_metrics: {e}")
-                raise
         finally:
-            logging.info("metrics collection stopped")
             logging.info("metrics collection stopped")
 
     async def run(self):
         logging.info("starting Roquefort")
-        logging.info("starting Roquefort")
-
         try:
-            # Start HTTP server only once
             if not self._server_started:
                 await self._server.run()
                 self._server_started = True
-
-            # Start metrics collection
             await self.update_metrics()
-        except (KeyboardInterrupt, SystemExit):
-            logging.info("shutdown signal received, stopping Roquefort gracefully")
-            logging.info("shutdown signal received, stopping Roquefort gracefully")
-            self._shutdown_event.set()
-        except Exception as e:
-            logging.exception(f"fatal error in run: {e}")
-            logging.exception(f"fatal error in run: {e}")
-            self._shutdown_event.set()
-            raise
         finally:
+            self._shutdown_event.set()
             logging.info("Roquefort stopped")
 
-    def _handle_task_generic(
-        self, event: dict, task: Task, metric_name: str, labels: dict = {}
-    ):
+    def _update_worker_metadata(self):
+        queues = self._get_active_queues()
+        for worker_name, queue_info_list in queues.items():
+            if worker_name not in self._workers_metadata:
+                self._workers_metadata[worker_name] = {"queues": []}
+            for queue in queue_info_list:
+                name = queue.get("name")
+                if name and name not in self._workers_metadata[worker_name]["queues"]:
+                    self._workers_metadata[worker_name]["queues"].append(name)
+
+    def _handle_worker_heartbeat(self, event):
+        hostname = event.get("hostname")
+        if hostname not in self._workers_metadata:
+            self._update_worker_metadata()
+            
+        worker_name, _ = get_worker_names(hostname)
+
+        queues = self._workers_metadata.get(hostname, {}).get("queues", ["unknown"])
+
+        self._metrics.set_gauge(
+            "worker_active",
+            True,
+            labels={"hostname": hostname, "worker": worker_name, "queue_name": format_queue_names(queues)},
+        )
+
+    def _handle_worker_status(self, event):
+        hostname = event.get("hostname")
+        worker_name, _ = get_worker_names(hostname)
         event_type = event.get("type")
 
-        logging.debug(f"event of type {event_type} received")
+        if event_type == "worker-online":
+            self._update_worker_metadata()
+            value = 1
+        else:
+            value = 0
 
-        if event_type not in self._tracked_events:
-            logging.warning(
-                f"event {event_type} not tracked. Will be processed as {metric_name}"
-            )
+        queue_name = get_queue_name_from_worker_metadata(hostname, self._workers_metadata) or self._default_queue_name
 
-    def _handle_task_generic(
-        self, event: dict, task: Task, metric_name: str, labels: dict = {}
-    ):
-        event_type = event.get("type")
+        self._metrics.set_gauge(
+            "worker_active",
+            value,
+            labels={"hostname": hostname, "worker": worker_name, "queue_name": queue_name},
+        )
 
-        logging.debug(f"event of type {event_type} received")
-
-        if event_type not in self._tracked_events:
-            logging.warning(
-                f"event {event_type} not tracked. Will be processed as {metric_name}"
-            )
-
-        try:
-            self._metrics.increment_counter(name=metric_name, labels=labels)
-        except Exception as e:
-            logging.error(f"error setting {metric_name} metric: {e}")
-            logging.error(f"error setting {metric_name} metric: {e}")
+    def _handle_task_generic(self, event, task, metric_name, labels):
+        if event.get("type") not in self._tracked_events:
+            logging.warning(f"Untracked event type: {event.get('type')}")
+        self._metrics.increment_counter(metric_name, labels)
 
     def _handle_task_sent(self, event):
-        task: Task = self._get_task_from_event(event)
-        queue_name = event.get("queue") or self._default_queue_name
-
+        task = self._get_task_from_event(event)
         labels = {
             "name": event.get("name"),
             "hostname": event.get("hostname"),
-            "queue_name": queue_name,
+            "queue_name": event.get("queue") or self._default_queue_name,
         }
-
-        task: Task = self._get_task_from_event(event)
-        queue_name = event.get("queue") or self._default_queue_name
-
-        labels = {
-            "name": event.get("name"),
-            "hostname": event.get("hostname"),
-            "queue_name": queue_name,
-        }
-
-        self._handle_task_generic(
-            event=event,
-            task=task,
-            metric_name="task_sent",
-            labels=labels,
-        )
+        self._handle_task_generic(event, task, "task_sent", labels)
 
     def _handle_task_received(self, event):
         task = self._get_task_from_event(event)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(
-                event.get("hostname"), self._workers_metadata
-            )
-            or self._default_queue_name
-        )
-
-        worker_name, _ = get_worker_names(event.get("hostname"))
-
+        hostname = event.get("hostname")
+        worker, _ = get_worker_names(hostname)
+        queue = getattr(task, "queue") or get_queue_name_from_worker_metadata(hostname, self._workers_metadata) or self._default_queue_name
         labels = {
             "name": event.get("name"),
-            "worker": worker_name,
-            "hostname": event.get("hostname"),
-            "queue_name": queue_name,
-        }
-
-        task = self._get_task_from_event(event)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(
-                event.get("hostname"), self._workers_metadata
-            )
-            or self._default_queue_name
-        )
-
-        worker_name, _ = get_worker_names(event.get("hostname"))
-
-        labels = {
-            "name": event.get("name"),
-            "worker": worker_name,
-            "hostname": event.get("hostname"),
-            "queue_name": queue_name,
-        }
-
-        self._handle_task_generic(
-            event=event,
-            task=task,
-            metric_name="task_received",
-            labels=labels,
-        )
-
-    def _handle_task_started(self, event):
-        task = self._get_task_from_event(event)
-
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        task = self._get_task_from_event(event)
-
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        self._handle_task_generic(
-            event=event,
-            task=task,
-            metric_name="task_started",
-            labels={
-                "name": getattr(task, "name"),
-                "worker": worker_name,
-                "hostname": hostname,
-                "queue_name": queue_name,
-            },
-        )
-
-    def _handle_task_succeeded(self, event):
-        task = self._get_task_from_event(event)
-
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        task = self._get_task_from_event(event)
-
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        self._handle_task_generic(
-            event=event,
-            task=task,
-            metric_name="task_succeeded",
-            labels={
-                "name": getattr(task, "name"),
-                "worker": worker_name,
-                "hostname": hostname,
-                "queue_name": queue_name,
-            },
-        )
-
-    def _handle_task_failed(self, event):
-        task = self._get_task_from_event(event)
-
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        exception = getattr(task, "exception", None) or event.get("exception")
-        exception_name = get_exception_name(exception)
-
-        self._handle_task_generic(
-            event=event,
-            task=task,
-            metric_name="task_failed",
-            labels={
-                "name": getattr(task, "name"),
-                "worker": worker_name,
-                "hostname": hostname,
-                "queue_name": queue_name,
-                "exception": exception_name,
-            },
-        )
-
-    def _handle_task_retried(self, event):
-        task = self._get_task_from_event(event)
-
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        exception = getattr(task, "exception", None) or event.get("exception")
-        exception_name = get_exception_name(exception)
-
-        self._handle_task_generic(
-            event=event,
-            task=task,
-            metric_name="task_retried",
-            labels={
-                "name": getattr(task, "name"),
-                "worker": worker_name,
-                "hostname": hostname,
-                "queue_name": queue_name,
-                "exception": exception_name,
-            },
-        )
-
-    def _handle_task_rejected(self, event):
-        task = self._get_task_from_event(event)
-
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        self._handle_task_generic(
-            event=event,
-            task=task,
-            metric_name="task_rejected",
-            labels={
-                "name": getattr(task, "name"),
-                "worker": worker_name,
-                "hostname": hostname,
-                "queue_name": queue_name,
-            },
-        )
-
-    def _handle_task_revoked(self, event):
-        task = self._get_task_from_event(event)
-
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-
-        queue_name = (
-            getattr(task, "queue")
-            or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        self._handle_task_generic(
-            event=event,
-            task=task,
-            metric_name="task_revoked",
-            labels={
-                "name": getattr(task, "name"),
-                "worker": worker_name,
-                "hostname": hostname,
-                "queue_name": queue_name,
-            },
-        )
-
-    def _handle_worker_heartbeat(self, event):
-        logging.debug(f"worker heartbeat received from {event.get('hostname')}")
-
-        worker_name = event.get("hostname")
-        if worker_name not in self._workers_metadata:
-            self._workers_metadata[worker_name] = {"queues": ["unknown"]}
-
-        worker_queues = self._workers_metadata.get(worker_name).get("queues")
-
-        try:
-            self._metrics.set_gauge(
-                name="worker_active",
-                value=True,
-                labels={
-                    "hostname": event["hostname"],
-                    "queue_name": format_queue_names(worker_queues),
-                },
-            )
-        except Exception as e:
-            logging.error(f"error setting worker_active metric: {e}")
-
-    def _handle_worker_status(self, event):
-        event_type = event.get("type")
-        hostname = event.get("hostname")
-        worker_name, _ = get_worker_names(hostname)
-        logging.debug(f"worker {worker_name} status event received: {event_type}")
-
-        value = 0
-        metadata = {}
-
-        if event_type == "worker-online":
-            value = 1
-            metadata = self._get_worker_metadata_by_hostname(hostname)
-            pprint(metadata)
-
-        queue_name = (
-            get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
-            or self._default_queue_name
-        )
-
-        labels = {
+            "worker": worker,
             "hostname": hostname,
-            "worker": worker_name,
-            "queue_name": queue_name,
+            "queue_name": queue,
         }
+        self._handle_task_generic(event, task, "task_received", labels)
 
-        try:
-            self._metrics.set_gauge(
-                name="worker_active",
-                value=value,
-                labels=labels,
-            )
-        except Exception as e:
-            logging.error(f"error setting worker_active metric: {e}")
+    def _handle_task_started(self, event): self._handle_task_lifecycle(event, "task_started")
+    def _handle_task_succeeded(self, event): self._handle_task_lifecycle(event, "task_succeeded")
+    def _handle_task_failed(self, event): self._handle_task_lifecycle(event, "task_failed", include_exception=True)
+    def _handle_task_retried(self, event): self._handle_task_lifecycle(event, "task_retried", include_exception=True)
+    def _handle_task_rejected(self, event): self._handle_task_lifecycle(event, "task_rejected")
+    def _handle_task_revoked(self, event): self._handle_task_lifecycle(event, "task_revoked")
 
-        # todo: add metrics handling for active processes.
-        # todo: add metrics handling for processed tasks.
+    def _handle_task_lifecycle(self, event, metric_name, include_exception=False):
+        task = self._get_task_from_event(event)
+        hostname = event.get("hostname")
+        worker, _ = get_worker_names(hostname)
+        queue = getattr(task, "queue") or get_queue_name_from_worker_metadata(hostname, self._workers_metadata) or self._default_queue_name
+        labels = {
+            "name": getattr(task, "name"),
+            "worker": worker,
+            "hostname": hostname,
+            "queue_name": queue,
+        }
+        if include_exception:
+            exception = getattr(task, "exception", None) or event.get("exception")
+            labels["exception"] = get_exception_name(exception)
+        self._handle_task_generic(event, task, metric_name, labels)
 
-    def _get_worker_metadata_by_hostname(self, hostname: str) -> dict:
-        metadata = self._workers_metadata.get(hostname)
-        if not metadata:
-            queues = self._get_active_queues()
-            metadata = queues.get(hostname)
-            if metadata:
-                self._workers_metadata[hostname] = metadata
-        return metadata
-
-    def _get_active_queues(self) -> dict:
-        """Get active queues from Celery app control interface.
-
-        Returns:
-            dict: Dictionary of active queues by worker name, or empty dict if none found.
-        """
+    def _get_active_queues(self):
         return self._app.control.inspect().active_queues() or {}
 
-    def _get_task_from_event(self, event) -> Task:
+    def _get_task_from_event(self, event):
         self._state.event(event)
         return self._state.tasks.get(event.get("uuid"))


### PR DESCRIPTION
This pull request introduces changes to enhance the Docker setup, improve the Makefile for Docker builds, and refactor the `roquefort.py` file to streamline worker metrics handling and event processing. Below is a summary of the most important changes:

### Docker and Build Improvements:
* **Dockerfile Updates**: Added a command to create and set permissions for the `.cache` directory for `appuser` and included a bind mount for `README.md` during dependency installation. Also added a `CMD` instruction to define the default container execution behavior. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R32-R34) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R45-R51)
* **Makefile Enhancements**: Introduced `IMAGE_REGISTRY` and `IMAGE_NAME` variables for Docker image naming, and added `docker-build`, `docker-build-base`, and `docker-build-app` targets to streamline the Docker build process. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R3) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R66-R73)

### Worker Metrics and Event Handling Refactor:
* **Metrics Update**: Modified the `worker_active` gauge to include an additional `worker` label for more granular monitoring.
* **Event Handlers Refactor**: Replaced individual task event handlers with a single `worker-online` and `worker-offline` handler (`_handle_worker_status`) to simplify worker status tracking. [[1]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L135-R153) [[2]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L527-R583)
* **Helper Methods**: Added `_get_worker_metadata_by_hostname` and `_get_active_queues` methods to centralize and simplify queue and metadata retrieval logic.