### PR TITLE
feat: enable metrics for worker status

### DIFF
--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Union
 import prometheus_client as prom
 
@@ -34,6 +35,9 @@ class MetricService:
 
     def set_gauge(self, name: str, value: Union[int, float, bool], labels: dict = None):
         labels = labels or {}
+        if name not in self.gauges:
+            logging.warning(f"gauge {name} not found. skipping")
+            return
         self.gauges[name].labels(**labels, **self._custom_labels).set(value)
 
     def create_counter(self, name: str, description: str, labels: list[str] = []):


### PR DESCRIPTION
This pull request introduces several updates to improve metric handling, enhance worker metadata management, and clean up unused code in the `src/metrics/metrics.py` and `src/roquefort.py` files. The most significant changes include adding new methods for worker metadata loading, modifying metrics to include additional labels, and replacing hardcoded logic with reusable functions.

### Metric Handling Improvements:
* Added a warning in `set_gauge` to log and skip updates for gauges that are not found in the `self.gauges` dictionary. (`src/metrics/metrics.py`, [src/metrics/metrics.pyR38-R40](diffhunk://#diff-a42b171683bb576ec18d77ec47b51a14eec1da10b01a74a736b18bc070cbcc4aR38-R40))
* Updated the `worker_active` metric to include a new `worker` label, providing more granular identification of workers. (`src/roquefort.py`, [src/roquefort.pyL91-R92](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L91-R92))

### Worker Metadata Management:
* Introduced a `_load_worker_metadata` method to dynamically load worker metadata, replacing hardcoded queue-loading logic. This method supports loading metadata for a specific worker or all workers. (`src/roquefort.py`, [src/roquefort.pyR521-R577](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R521-R577))
* Modified the `_handle_worker_heartbeat` and `_handle_worker_status` methods to utilize the new `_load_worker_metadata` method and ensure consistent handling of worker metadata. (`src/roquefort.py`, [[1]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L509-R512) [[2]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R521-R577)

### Code Cleanup and Refactoring:
* Commented out unused task-related event handlers in the `update_metrics` method and replaced them with a unified worker status handler (`_handle_worker_status`). (`src/roquefort.py`, [src/roquefort.pyL135-R154](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L135-R154))
* Simplified queue name resolution by introducing reusable helper functions like `get_queue_name_from_worker_metadata`. (`src/roquefort.py`, [src/roquefort.pyL509-R512](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L509-R512))

These changes streamline the codebase, improve maintainability, and enhance the flexibility of metric and worker management.