### PR TITLE
feat: add timeout purge for worker metrics

### DIFF
--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -72,3 +72,16 @@ class MetricService:
 
     def get_registry(self):
         return self._registry
+
+    def remove_gauge_by_label_value(self, name: str, value: str):
+        gauge = self.gauges.get(name)
+
+        if not gauge:
+            logging.info(f"gauge {name} not found. skipping")
+            return
+        labels = list(gauge._metrics.keys())
+
+        for label_list in list(labels):
+            if value in label_list:
+                logging.info(f"removing label {label_list} for gauge {name}")
+                gauge.remove(*label_list)

--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Union
 import prometheus_client as prom
 
@@ -34,6 +35,9 @@ class MetricService:
 
     def set_gauge(self, name: str, value: Union[int, float, bool], labels: dict = None):
         labels = labels or {}
+        if name not in self.gauges:
+            logging.warning(f"gauge {name} not found. skipping")
+            return
         self.gauges[name].labels(**labels, **self._custom_labels).set(value)
 
     def create_counter(self, name: str, description: str, labels: list[str] = []):

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -140,8 +140,7 @@ class Roquefort:
             queue_name = metadata["queues"][0] or self._default_queue_name
 
             if (
-                hostname.startswith("a1111-upscaler")
-                or time.time() - metadata["last_heartbeat"]
+                time.time() - metadata["last_heartbeat"]
                 > self._worker_heartbeat_timeout * 5
             ):
                 logging.warning(f"purging metrics for worker {worker}")


### PR DESCRIPTION
This pull request introduces significant updates to the `src/roquefort.py` and `src/metrics/metrics.py` files, focusing on enhancing worker monitoring, improving event handling, and adding new utility methods. The most notable changes include the addition of worker purging logic, a new worker heartbeat timeout parameter, and refactoring of event consumption to improve maintainability.

### Worker Monitoring Enhancements:
* Introduced a `_purger` method to remove inactive workers and update worker metrics based on heartbeat activity. Workers exceeding the heartbeat timeout or matching specific conditions are purged. (`src/roquefort.py`)
* Added `_worker_heartbeat_timeout` parameter to the `Roquefort` class to configure heartbeat timeout duration. (`src/roquefort.py`) [[1]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R30) [[2]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R46)

### Event Handling Improvements:
* Refactored event consumption logic by introducing `_consume_events` and `_consume_events_loop` methods, enabling non-blocking event handling using `asyncio`. (`src/roquefort.py`)
* Updated `update_metrics` to concurrently run event consumption and worker purging using asyncio tasks. (`src/roquefort.py`)

### Utility Method Additions:
* Added `remove_gauge_by_label_value` method in `src/metrics/metrics.py` to facilitate the removal of specific gauge labels. (`src/metrics/metrics.py`)
* Implemented `_load_worker_metadata` to dynamically fetch and update worker metadata, supporting both specific and all workers. (`src/roquefort.py`)

These changes collectively improve the system's robustness in handling worker metrics, streamline event processing, and enhance the maintainability of the codebase.