### PR TITLE
fix: load worker metadata defined twice

### DIFF
--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -152,7 +152,10 @@ class Roquefort:
                 workers_to_remove.append(worker)
                 continue
 
-            if time.time() - metadata["last_heartbeat"] > self._worker_heartbeat_timeout:
+            if (
+                time.time() - metadata["last_heartbeat"]
+                > self._worker_heartbeat_timeout
+            ):
                 logging.debug(f"setting worker_active to 0 for worker {worker}")
                 self._metrics.set_gauge(
                     name="worker_active",
@@ -217,7 +220,9 @@ class Roquefort:
             consume_task = asyncio.create_task(self._consume_events_loop(handlers))
             purge_task = asyncio.create_task(self._purger_loop())
 
-            await asyncio.wait([consume_task, purge_task], return_when=asyncio.FIRST_COMPLETED)
+            await asyncio.wait(
+                [consume_task, purge_task], return_when=asyncio.FIRST_COMPLETED
+            )
 
         except (KeyboardInterrupt, SystemExit):
             logging.info("Shutdown signal received, stopping metrics collection")
@@ -590,13 +595,18 @@ class Roquefort:
         if hostname and hostname in self._workers_metadata:
             return
 
-        destination = [hostname] if hostname else None 
+        destination = [hostname] if hostname else None
 
-        queues = self._app.control.inspect(destination=destination).active_queues() or {}
+        queues = (
+            self._app.control.inspect(destination=destination).active_queues() or {}
+        )
 
         for worker_name, queue_info_list in queues.items():
             if worker_name not in self._workers_metadata:
-                self._workers_metadata[worker_name] = {"queues": [], "last_heartbeat": time.time()}
+                self._workers_metadata[worker_name] = {
+                    "queues": [],
+                    "last_heartbeat": time.time(),
+                }
 
             for queue_info in queue_info_list:
                 queue_name = queue_info.get("name")

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -151,7 +151,7 @@ class Roquefort:
                 )
                 workers_to_remove.append(worker)
                 continue
-            
+
             if time.time() - metadata["last_heartbeat"] > self._worker_heartbeat_timeout:
                 logging.debug(f"setting worker_active to 0 for worker {worker}")
                 self._metrics.set_gauge(
@@ -164,7 +164,7 @@ class Roquefort:
                     },
                 )
                 continue
-            
+
         for worker in workers_to_remove:
             del self._workers_metadata[worker]
 
@@ -584,28 +584,6 @@ class Roquefort:
     def _get_task_from_event(self, event) -> Task:
         self._state.event(event)
         return self._state.tasks.get(event.get("uuid"))
-
-    def _load_worker_metadata(self, hostname: str = None) -> None:
-
-        if hostname and hostname in self._workers_metadata:
-            return
-
-        destination = [hostname] if hostname else None 
-
-        queues = self._app.control.inspect(destination=destination).active_queues() or {}
-
-        for worker_name, queue_info_list in queues.items():
-            if worker_name not in self._workers_metadata:
-                self._workers_metadata[worker_name] = {"queues": [], "last_heartbeat": time.time()}
-
-            for queue_info in queue_info_list:
-                queue_name = queue_info.get("name")
-
-                if not queue_name:
-                    continue
-
-                if queue_name not in self._workers_metadata[worker_name]["queues"]:
-                    self._workers_metadata[worker_name]["queues"].append(queue_name)
 
     def _load_worker_metadata(self, hostname: str = None) -> None:
 


### PR DESCRIPTION
This pull request introduces formatting improvements to enhance code readability in the `src/roquefort.py` file. The changes primarily involve reformatting long lines to conform to PEP 8 style guidelines by breaking them into multiple lines.

### Code readability improvements:

* Reformatted a conditional statement in the `_purger` method to span multiple lines, improving clarity and adherence to PEP 8. (`src/roquefort.py`, [src/roquefort.pyL155-R158](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L155-R158))
* Reformatted the `asyncio.wait` call in the `update_metrics` method to break the arguments into multiple lines for better readability. (`src/roquefort.py`, [src/roquefort.pyL220-R225](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L220-R225))
* Reformatted dictionary initialization and method calls in the `_load_worker_metadata` method to use multi-line formatting, making the code more readable and consistent. (`src/roquefort.py`, [src/roquefort.pyL595-R609](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L595-R609))