### PR TITLE
fix: avoid index error when accesing lists

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -43,6 +43,10 @@ def get_queue_name_from_worker_metadata(worker: str, metadata: dict) -> str:
 
     queues = worker_metadata.get("queues", [])
 
+    if not queues:
+        logging.warning(f"no queues found for {worker}")
+        return None
+
     if len(queues) != 1:
         logging.warning(f"multiple queues found for {worker}: {queues}")
         return None

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -137,7 +137,11 @@ class Roquefort:
         for worker, metadata in self._workers_metadata.items():
             hostname = worker
             worker_name, _ = get_worker_names(hostname)
-            queue_name = metadata["queues"][0] or self._default_queue_name
+            queue_name = (
+                metadata["queues"][0]
+                if metadata["queues"]
+                else self._default_queue_name
+            )
 
             if (
                 time.time() - metadata["last_heartbeat"]
@@ -150,7 +154,7 @@ class Roquefort:
                 )
                 workers_to_remove.append(worker)
                 continue
-            
+
             if time.time() - metadata["last_heartbeat"] > self._worker_heartbeat_timeout:
                 logging.debug(f"setting worker_active to 0 for worker {worker}")
                 self._metrics.set_gauge(
@@ -163,7 +167,7 @@ class Roquefort:
                     },
                 )
                 continue
-            
+
         for worker in workers_to_remove:
             del self._workers_metadata[worker]
 


### PR DESCRIPTION
This pull request introduces changes to improve error handling and ensure robustness in queue management. Specifically, it adds a safeguard for cases where no queues are found in worker metadata and refines queue assignment logic in the purger process.

### Error Handling Improvements:
* [`src/helpers.py`](diffhunk://#diff-1ba52bbd54b0d0cfad2be0af4d1b3363e541454f522ba8efd6239a2953c1ea11R46-R49): Added a check in `get_queue_name_from_worker_metadata` to handle cases where no queues are found in the worker metadata. A warning is logged, and `None` is returned.

### Queue Assignment Refinements:
* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L140-R144): Updated the `_purger` method to handle cases where the `queues` list in metadata is empty. It now assigns the default queue name if no queues are specified.