### PR TITLE
feat: add chart for kubernetes easy deployment

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -1,0 +1,34 @@
+name: Release Helm Charts
+
+on:
+  workflow_dispatch: {}
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.14.4
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "{{ .Name }}-chart-{{ .Version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,3 +47,8 @@ jobs:
         run: gh workflow run push-docker-image-to-ghcr.yaml --ref "$(git describe --tags --abbrev=0)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger Helm chart release workflow
+        run: gh workflow run helm-chart-release.yaml --ref "$(git describe --tags --abbrev=0)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/celery-roquefort/Chart.yaml
+++ b/charts/celery-roquefort/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: celery-roquefort
+description: A Helm chart for Celery Roquefort
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+home: https://github.com/freepik-company/celery-roquefort
+keywords:
+  - celerty
+  - metrics
+  - prometheus
+sources:
+  - https://github.com/freepik-company/celery-roquefort
+maintainers:
+  - name: José Antonio Muriano Criado
+    email: jamuriano@freepik.com

--- a/charts/celery-roquefort/templates/NOTES.txt
+++ b/charts/celery-roquefort/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "celery-roquefort.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "celery-roquefort.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "celery-roquefort.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "celery-roquefort.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/celery-roquefort/templates/_helpers.tpl
+++ b/charts/celery-roquefort/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "celery-roquefort.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "celery-roquefort.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "celery-roquefort.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "celery-roquefort.labels" -}}
+helm.sh/chart: {{ include "celery-roquefort.chart" . }}
+{{ include "celery-roquefort.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "celery-roquefort.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "celery-roquefort.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "celery-roquefort.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "celery-roquefort.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/celery-roquefort/templates/deployment.yaml
+++ b/charts/celery-roquefort/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "celery-roquefort.fullname" . }}
+  labels:
+    {{- include "celery-roquefort.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "celery-roquefort.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "celery-roquefort.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "celery-roquefort.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/celery-roquefort/templates/deployment.yaml
+++ b/charts/celery-roquefort/templates/deployment.yaml
@@ -5,9 +5,7 @@ metadata:
   labels:
     {{- include "celery-roquefort.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "celery-roquefort.selectorLabels" . | nindent 6 }}

--- a/charts/celery-roquefort/templates/ingress.yaml
+++ b/charts/celery-roquefort/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "celery-roquefort.fullname" . }}
+  labels:
+    {{- include "celery-roquefort.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "celery-roquefort.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/celery-roquefort/templates/service.yaml
+++ b/charts/celery-roquefort/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "celery-roquefort.fullname" . }}
+  labels:
+    {{- include "celery-roquefort.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "celery-roquefort.selectorLabels" . | nindent 4 }}

--- a/charts/celery-roquefort/templates/serviceaccount.yaml
+++ b/charts/celery-roquefort/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "celery-roquefort.serviceAccountName" . }}
+  labels:
+    {{- include "celery-roquefort.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/celery-roquefort/templates/servicemonitor.yaml
+++ b/charts/celery-roquefort/templates/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "celery-roquefort.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace | quote }}
+{{- end }}
+  labels:
+    {{- include "celery-roquefort.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: http
+      interval: {{ .Values.serviceMonitor.scrapeInterval | default "15s" }}
+    {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: true
+    {{- end }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | default "10s" }}
+    {{- if .Values.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+{{- if .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel | quote }}
+{{- end }}
+{{- if .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml .Values.serviceMonitor.namespaceSelector | nindent 4 }}
+{{- else }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+  {{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "celery-roquefort.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/celery-roquefort/templates/servicemonitor.yaml
+++ b/charts/celery-roquefort/templates/servicemonitor.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   endpoints:
     - port: http
-      interval: {{ .Values.serviceMonitor.scrapeInterval | default "15s" }}
+      interval: {{ .Values.serviceMonitor.interval | default "15s" }}
     {{- if .Values.serviceMonitor.honorLabels }}
       honorLabels: true
     {{- end }}

--- a/charts/celery-roquefort/templates/tests/test-connection.yaml
+++ b/charts/celery-roquefort/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "celery-roquefort.fullname" . }}-test-connection"
+  labels:
+    {{- include "celery-roquefort.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "celery-roquefort.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/celery-roquefort/values.yaml
+++ b/charts/celery-roquefort/values.yaml
@@ -1,0 +1,111 @@
+# Default values for celery-roquefort.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: freepik-company/celery-roquefort
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 9090
+  annotations: {}
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: celery-roquefort.test
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe: {}
+
+readinessProbe: {}
+
+
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/celery-roquefort/values.yaml
+++ b/charts/celery-roquefort/values.yaml
@@ -89,23 +89,22 @@ livenessProbe: {}
 
 readinessProbe: {}
 
-
-
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
-
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
+
+env: []
+
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+  namespace: ""
+  namespaceSelector: {}
+  interval: 15s
+  scrapeTimeout: 10s
+  honorLabels: false
+  targetLabels: []
+  relabelings: []
+  metricRelabelings: []


### PR DESCRIPTION
This pull request introduces a Helm chart for deploying the `celery-roquefort` application, along with a GitHub Actions workflow for releasing Helm charts. The changes include the creation of Helm chart templates, default values, and associated Kubernetes resources, as well as the integration of the Helm chart release process into the CI/CD pipeline.

### Helm Chart for `celery-roquefort` Deployment

* **Chart Definition**: Added `Chart.yaml` to define the Helm chart metadata, including name, version, description, and maintainers.
* **Templates**: Created Kubernetes resource templates for deployment (`deployment.yaml`), service (`service.yaml`), ingress (`ingress.yaml`), service account (`serviceaccount.yaml`), service monitor (`servicemonitor.yaml`), and connection test (`test-connection.yaml`). These templates use Helm functions for dynamic configuration. [[1]](diffhunk://#diff-1e970f66ffbe0f7b374f638f33890d60215676035b4ec0b0e3011625f793804bR1-R76) [[2]](diffhunk://#diff-ec0d9196bb54925954580284a62befd3a755912e772320593e7b29d8bfcfb487R1-R15) [[3]](diffhunk://#diff-4690c4da255ea5f25dd95ea1f7f7da5c205d9e64c8960096d8a0f0a7708a0d4dR1-R43) [[4]](diffhunk://#diff-a1faaf731e233dbe0bf39be18064fac7c9d1b9a5d65d15abd59c0ec9541b2746R1-R13) [[5]](diffhunk://#diff-9357848df103e7e935764b8a9b9b814143d598a1b65cd5c0667ec2736e4c17c9R1-R47) [[6]](diffhunk://#diff-00af6b9b6c1c7d91d0639e2cc0fe109746c43d34750d25365862813446618b55R1-R15)
* **Helper Functions**: Added `_helpers.tpl` to define reusable Helm template functions for naming and labeling resources.
* **Default Values**: Added `values.yaml` to provide default configurations for replicas, image settings, service type, ingress, probes, resource limits, and service monitor.

### GitHub Actions Workflow for Helm Chart Release

* **New Workflow**: Added `helm-chart-release.yaml` to automate the process of releasing Helm charts. This includes setting up Helm, configuring Git, and running the chart-releaser action.
* **CI/CD Integration**: Updated `release.yaml` to trigger the Helm chart release workflow after a successful release tag push.