### PR TITLE
feat: add env vars from values to deployment

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -1,11 +1,8 @@
-name: "Create and publish a Docker image to ghcr.io"
+name: "Release Docker Image"
 
 on:
   workflow_dispatch: {}
-  push:
-    tags:
-      - '*'
-      - 'v*'
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -2,9 +2,7 @@ name: Release Helm Charts
 
 on:
   workflow_dispatch: {}
-  push:
-    tags:
-      - "*"
+
 
 jobs:
   release:

--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Version Tag
 
 permissions:
   contents: write
@@ -38,17 +38,21 @@ jobs:
       - name: Create release
         run: |
           cz bump --changelog --yes -at
+          sed -i "s/version: .*/version: $(git describe --tags --abbrev=0)/" charts/celery-roquefort/Chart.yaml
+          sed -i "s/appVersion: .*/appVersion: $(git describe --tags --abbrev=0)/" charts/celery-roquefort/Chart.yaml
+          git add charts/celery-roquefort/Chart.yaml
+          git commit --amend --no-edit
           git push
           git push --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger Docker build workflow
-        run: gh workflow run push-docker-image-to-ghcr.yaml --ref "$(git describe --tags --abbrev=0)"
+        run: gh workflow run release-docker.yaml --ref "$(git describe --tags --abbrev=0)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger Helm chart release workflow
-        run: gh workflow run helm-chart-release.yaml --ref "$(git describe --tags --abbrev=0)"
+        run: gh workflow run release-helm-chart.yaml --ref "$(git describe --tags --abbrev=0)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/celery-roquefort/templates/deployment.yaml
+++ b/charts/celery-roquefort/templates/deployment.yaml
@@ -58,6 +58,8 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This pull request focuses on renaming and updating GitHub Actions workflows to improve clarity and consistency, as well as enhancing the Helm chart configuration for versioning and environment variable support. Below is a summary of the most important changes:

### Workflow Renaming and Updates

* [`.github/workflows/release-docker.yaml`](diffhunk://#diff-482d327c9542f8be116eab7e5b5acc5f93bac125c51c9ab706023808fed3fbe6L1-R5): Renamed from `push-docker-image-to-ghcr.yaml` and updated the workflow name to "Release Docker Image" for better clarity. Removed the `push` trigger for tags.
* [`.github/workflows/release-helm-chart.yaml`](diffhunk://#diff-e8ab89697c74b1c0ed27126a59f2e685bdfe385b1495bb49112580a92f20ec24L5-R5): Renamed from `helm-chart-release.yaml` and updated the workflow name to "Release Helm Charts." Removed the `push` trigger for tags.
* [`.github/workflows/release-version.yaml`](diffhunk://#diff-1ddfe6fd186c08d191f62d469c9320b05b1bf7daf4894009494e79f09872cf6dL1-R1): Renamed from `release.yaml` and updated the workflow name to "Release Version Tag." Added commands to update the `version` and `appVersion` fields in `charts/celery-roquefort/Chart.yaml` during the release process. Updated references to renamed workflows for triggering Docker and Helm chart releases. [[1]](diffhunk://#diff-1ddfe6fd186c08d191f62d469c9320b05b1bf7daf4894009494e79f09872cf6dL1-R1) [[2]](diffhunk://#diff-1ddfe6fd186c08d191f62d469c9320b05b1bf7daf4894009494e79f09872cf6dR41-R56)

### Helm Chart Enhancements

* [`charts/celery-roquefort/templates/deployment.yaml`](diffhunk://#diff-1e970f66ffbe0f7b374f638f33890d60215676035b4ec0b0e3011625f793804bR61-R62): Added support for environment variables in the Helm chart by introducing the `env` key under `spec`. This allows dynamic configuration based on `Values.env`.