### PR TITLE
fix: avoid AttributeError when access to task queue in some scenarios

### DIFF
--- a/.github/workflows/release-version.yaml
+++ b/.github/workflows/release-version.yaml
@@ -38,7 +38,6 @@ jobs:
       - name: Create release
         run: |
           cz bump --changelog --yes -at
-          sed -i "s/version: .*/version: $(git describe --tags --abbrev=0)/" charts/celery-roquefort/Chart.yaml
           sed -i "s/appVersion: .*/appVersion: $(git describe --tags --abbrev=0)/" charts/celery-roquefort/Chart.yaml
           git add charts/celery-roquefort/Chart.yaml
           git commit --amend --no-edit

--- a/charts/celery-roquefort/Chart.yaml
+++ b/charts/celery-roquefort/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: celery-roquefort
 description: A Helm chart for Celery Roquefort
 type: application
-version: 0.6.1
+version: 0.7.0
 appVersion: 0.6.1
 home: https://github.com/freepik-company/celery-roquefort
 keywords:

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -305,7 +305,7 @@ class Roquefort:
         task = self._get_task_from_event(event)
 
         queue_name = (
-            getattr(task, "queue")
+            getattr(task, "queue", None)
             or get_queue_name_from_worker_metadata(
                 event.get("hostname"), self._workers_metadata
             )
@@ -335,7 +335,7 @@ class Roquefort:
         worker_name, _ = get_worker_names(hostname)
 
         queue_name = (
-            getattr(task, "queue")
+            getattr(task, "queue", None)
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )
@@ -359,7 +359,7 @@ class Roquefort:
         worker_name, _ = get_worker_names(hostname)
 
         queue_name = (
-            getattr(task, "queue")
+            getattr(task, "queue", None)
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )
@@ -383,7 +383,7 @@ class Roquefort:
         worker_name, _ = get_worker_names(hostname)
 
         queue_name = (
-            getattr(task, "queue")
+            getattr(task, "queue", None)
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )
@@ -411,7 +411,7 @@ class Roquefort:
         worker_name, _ = get_worker_names(hostname)
 
         queue_name = (
-            getattr(task, "queue")
+            getattr(task, "queue", None)
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )
@@ -439,7 +439,7 @@ class Roquefort:
         worker_name, _ = get_worker_names(hostname)
 
         queue_name = (
-            getattr(task, "queue")
+            getattr(task, "queue", None)
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )
@@ -463,7 +463,7 @@ class Roquefort:
         worker_name, _ = get_worker_names(hostname)
 
         queue_name = (
-            getattr(task, "queue")
+            getattr(task, "queue", None)
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )


### PR DESCRIPTION
This pull request includes changes to improve error handling in `src/roquefort.py`, update the Helm chart version, and modify the release workflow. The most significant changes enhance robustness in queue name resolution, increment the chart version, and simplify the release process.

### Error Handling Improvements:
* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L308-R308): Updated multiple methods (`_handle_task_received`, `_handle_task_started`, `_handle_task_succeeded`, `_handle_task_failed`, `_handle_task_retried`, `_handle_task_rejected`, `_handle_task_revoked`) to use `getattr(task, "queue", None)` instead of `getattr(task, "queue")`. This ensures that a default value of `None` is returned if the `queue` attribute is missing, improving error handling. [[1]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L308-R308) [[2]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L338-R338) [[3]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L362-R362) [[4]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L386-R386) [[5]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L414-R414) [[6]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L442-R442) [[7]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L466-R466)

### Helm Chart Version Update:
* [`charts/celery-roquefort/Chart.yaml`](diffhunk://#diff-d817d683c00c442ae90d01754b7490f7fa0039476d37622d3cd35a0effb4cf0bL5-R5): Incremented the `version` field from `0.6.1` to `0.7.0` to reflect the new release.

### Release Workflow Simplification:
* [`.github/workflows/release-version.yaml`](diffhunk://#diff-1ddfe6fd186c08d191f62d469c9320b05b1bf7daf4894009494e79f09872cf6dL41): Removed the line that updates the `version` field in the Helm chart during the release process, leaving only the `appVersion` field update. This simplifies the workflow.