### PR TITLE
feat: add metrics for queue length

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -62,3 +62,30 @@ def get_exception_name(message: str) -> str:
     if match:
         return match.group(1)
     return "unknown"
+
+
+def is_valid_transport(transport: str) -> bool:
+    """Check if the transport is valid.
+
+    Args:
+        transport (str): The transport name.
+    """
+    
+    # TODO: add more transports
+    return transport in ["redis", "rediss", "sentinel"]
+
+def get_queue_length(connection, transport: str, queue_name: str) -> int:
+    
+    if transport in ["redis", "rediss", "sentinel"]:
+        return get_redis_queue_length(connection, queue_name)
+    
+    return 0
+
+def get_redis_queue_length(connection, queue_name: str) -> int:
+    """Get the length of a Redis queue.
+
+    Args:
+        connection (Connection): The Redis connection.
+        queue_name (str): The name of the queue.
+    """
+    return connection.default_channel.client.llen(queue_name)

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -1,18 +1,8 @@
 import asyncio
-from contextlib import asynccontextmanager
 import logging
-import time
-from typing import Callable
-from fastapi import FastAPI
-import uvicorn
 from prometheus_client import (
-    disable_created_metrics,
-    make_asgi_app,
-    Counter,
     start_http_server,
 )
-
-from ..metrics.metrics import MetricService
 
 
 class HttpServer:


### PR DESCRIPTION
This pull request introduces enhancements to queue length tracking and metrics collection in the `roquefort` module, alongside utility functions in the `helpers` module. Key changes include adding queue length calculation functionality, integrating it into the metrics update loop, and modifying the initialization process to support queue tracking.

### Queue length tracking and metrics collection:

* **New utility functions in `src/helpers.py`:** Added `is_valid_transport`, `get_queue_length`, and `get_redis_queue_length` functions to validate transport types and calculate queue lengths for Redis-based transports.
* **Queue length calculation in `src/roquefort.py`:** Introduced `_calculate_queue_length` and `_calculate_queue_length_loop` methods to compute and periodically update queue lengths using Prometheus gauges.

### Integration into `roquefort`:

* **Initialization changes:** Added `queue_length_interval` parameter and `_queues` attribute to track queues and define the interval for queue length updates. [[1]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R33) [[2]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R50-R51)
* **Metrics update loop:** Integrated queue length calculation into the `update_metrics` method and its event loop, ensuring queue lengths are tracked alongside other metrics.
* **Queue discovery:** Modified `_load_worker_metadata` to append discovered queue names to the `_queues` list for tracking.

### Minor adjustments:

* **Event consumption timeout:** Updated `_consume_events` to remove the timeout parameter, preventing premature termination during event capture.