### PR TITLE
feat: add metrics handling for active worker tasks

### DIFF
--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -548,7 +548,22 @@ class Roquefort:
         except Exception as e:
             logging.error(f"error setting worker_active metric: {e}")
 
-        # todo: add metrics handling for active processes.
+        active_tasks = event.get("active", 0)
+        
+        try: 
+            self._metrics.set_gauge(
+                name="worker_tasks_active",
+                value=active_tasks,
+                labels={
+                    "hostname": hostname,
+                    "worker": worker_name,
+                    "queue_name": queue_name,
+                },
+            )
+        except Exception as e:
+            logging.error(f"error setting worker_tasks_active metric: {e}")
+        
+        
         # todo: add metrics handling for processed tasks.
 
     def _handle_worker_status(self, event):


### PR DESCRIPTION
* Implemented metrics tracking for active tasks in the Roquefort class.
* Added error handling for setting the worker_tasks_active metric.
This pull request introduces a new metric to track the number of active tasks for workers in the `_handle_worker_heartbeat` method of `src/roquefort.py`.

Metrics enhancement:

* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L551-R566): Added logic to set a gauge metric named `worker_tasks_active` to monitor the number of active tasks for workers. The metric includes labels for `hostname`, `worker`, and `queue_name`.