### PR TITLE
feat: task runtime metric

### DIFF
--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -69,6 +69,13 @@ class MetricService:
             labelnames=labels,
             registry=self._registry,
         )
+        
+    def register_histogram(self, name: str, value: Union[int, float], labels: dict = None):
+        labels = labels or {}
+        if name not in self.histograms:
+            logging.warning(f"histogram {name} not found. skipping")
+            return
+        self.histograms[name].labels(**labels, **self._custom_labels).observe(value)
 
     def get_registry(self):
         return self._registry

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -112,11 +112,6 @@ class Roquefort:
             labels=["queue_name"],
         )
         self._metrics.create_gauge(
-            "active_worker_count",
-            "The number of active workers in broker queue.",
-            labels=["queue_name"],
-        )
-        self._metrics.create_gauge(
             "active_process_count",
             "The number of active processes in broker queue.",
             labels=["queue_name"],

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -388,6 +388,7 @@ class Roquefort:
         task = self._get_task_from_event(event)
 
         hostname = event.get("hostname")
+        runtime = event.get("runtime")
         worker_name, _ = get_worker_names(hostname)
 
         queue_name = (
@@ -395,18 +396,33 @@ class Roquefort:
             or get_queue_name_from_worker_metadata(hostname, self._workers_metadata)
             or self._default_queue_name
         )
+        task_name = getattr(task, "name")
 
         self._handle_task_generic(
             event=event,
             task=task,
             metric_name="task_succeeded",
             labels={
-                "name": getattr(task, "name"),
+                "name": task_name,
                 "worker": worker_name,
                 "hostname": hostname,
                 "queue_name": queue_name,
             },
         )
+        
+        try:
+            self._metrics.register_histogram(
+                name="task_runtime",
+                value=runtime,
+                labels={
+                    "name": getattr(task, "name"),
+                    "hostname": hostname,
+                    "queue_name": queue_name,
+                },
+            )
+        except Exception as e:
+            logging.error(f"error setting task_runtime metric: {e}")
+            
 
     def _handle_task_failed(self, event):
         task = self._get_task_from_event(event)

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -415,7 +415,7 @@ class Roquefort:
                 name="task_runtime",
                 value=runtime,
                 labels={
-                    "name": getattr(task, "name"),
+                    "name": task_name,
                     "hostname": hostname,
                     "queue_name": queue_name,
                 },


### PR DESCRIPTION
This pull request introduces enhancements to metric tracking and refactors existing code in `src/metrics/metrics.py` and `src/roquefort.py`. The key changes include adding a method for histogram registration, improving task runtime tracking, and removing redundant gauge creation.

### Enhancements to metric tracking:

* [`src/metrics/metrics.py`](diffhunk://#diff-a42b171683bb576ec18d77ec47b51a14eec1da10b01a74a736b18bc070cbcc4aR73-R79): Added a new method `register_histogram` to facilitate histogram metric registration, including error handling for missing histograms.
* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R391-R426): Enhanced `_handle_task_succeeded` to track task runtime using the newly added `register_histogram` method, with error logging for exceptions.

### Code refactoring:

* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L114-L118): Removed the creation of a redundant gauge metric `active_worker_count` from the `__init__` method, simplifying initialization.