### PR TITLE
fix(Roquefort): queue length metric was not aplying queue filter

### DIFF
--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -204,6 +204,9 @@ class Roquefort:
                 return
             
             for queue_name in self._queues:
+                if not self._should_monitor_queue(queue_name):
+                    continue
+                
                 length = get_queue_length(connection, transport, queue_name)
                 
                 self._metrics.set_gauge(


### PR DESCRIPTION
This pull request includes a small change to the `src/roquefort.py` file. The change adds a conditional check to skip monitoring queues that do not meet certain criteria, improving the efficiency of the `_calculate_queue_length` method.