### PR TITLE
fix: handle empty exception after some time running

### DIFF
--- a/src/thread_manager.py
+++ b/src/thread_manager.py
@@ -100,7 +100,7 @@ class ThreadManager:
                 try:
                     with roquefort_instance._app.connection() as connection:
                         recv = roquefort_instance._app.events.Receiver(connection, handlers=handlers)
-                        recv.capture(limit=None, timeout=1.0, wakeup=True)
+                        recv.capture(limit=None, timeout=None,wakeup=True)
                 except Exception as e:
                     logging.exception(f"Error in event consumer - Connection or receiver failed: {e}")
                     time.sleep(1)


### PR DESCRIPTION
This pull request refactors the `Roquefort` class and its related components to introduce a unified threading model for metrics collection, replace asynchronous methods with synchronous counterparts, and improve error handling. It also updates the `FastAPIServer` to support a lifespan method for better integration with the `Roquefort` lifecycle.

### Refactoring for Unified Threading Model:
* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L40-R53): Replaced asynchronous methods (`_purger_loop`, `_calculate_queue_length_loop`, `_consume_events_loop`) with synchronous counterparts using the new `ThreadManager` class. Unified threading improves resource management and simplifies lifecycle operations. [[1]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L40-R53) [[2]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L175-L207) [[3]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R200-R323)
* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R200-R323): Introduced `start_metrics_collection` and `stop_metrics_collection` methods to manage the lifecycle of metrics collection using `ThreadManager`.

### FastAPI Server Integration:
* [`src/server/server.py`](diffhunk://#diff-e0bb43e77afdc23f85aefba41e3d8fda1554c6402c8e08536508ed6246d8068fL52-R68): Enhanced `FastAPIServer` to support a lifespan method, allowing integration with `Roquefort` lifecycle operations such as metrics collection.
* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R200-R323): Added `create_fastapi_server` to initialize the FastAPI server with lifespan and health check methods.

### Error Handling Improvements:
* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L319-R343): Replaced `logging.error` with `logging.exception` in multiple handlers to provide detailed stack traces for debugging. [[1]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L319-R343) [[2]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L437-R461) [[3]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L586-R610) [[4]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L601-R625) [[5]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R663-R664) [[6]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0R694-R695)