### PR TITLE
feat: purge metrics involved in hostname lost

### DIFF
--- a/src/metrics/metrics.py
+++ b/src/metrics/metrics.py
@@ -80,15 +80,26 @@ class MetricService:
     def get_registry(self):
         return self._registry
 
-    def remove_gauge_by_label_value(self, name: str, value: str):
-        gauge = self.gauges.get(name)
+    def _remove_metric_by_label_value(self, metrics_dict: dict, metric_type: str, name: str, value: str):
+        """Private method to remove metrics by label value from any metric type collection."""
+        metric = metrics_dict.get(name)
 
-        if not gauge:
-            logging.info(f"gauge {name} not found. skipping")
+        if not metric:
+            logging.info(f"{metric_type} {name} not found. skipping")
             return
-        labels = list(gauge._metrics.keys())
+        
+        labels = list(metric._metrics.keys())
 
         for label_list in list(labels):
             if value in label_list:
-                logging.info(f"removing label {label_list} for gauge {name}")
-                gauge.remove(*label_list)
+                logging.info(f"removing label {label_list} for {metric_type} {name}")
+                metric.remove(*label_list)
+
+    def remove_gauge_by_label_value(self, name: str, value: str):
+        self._remove_metric_by_label_value(self.gauges, "gauge", name, value)
+                
+    def remove_counter_by_label_value(self, name: str, value: str):
+        self._remove_metric_by_label_value(self.counters, "counter", name, value)
+                
+    def remove_histogram_by_label_value(self, name: str, value: str):
+        self._remove_metric_by_label_value(self.histograms, "histogram", name, value)

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -128,9 +128,8 @@ class Roquefort:
     def _purger(self):
         """Purge metrics for inactive workers."""
         logging.debug("purging metrics")
-        workers_to_remove = []
 
-        for worker, metadata in self._workers_metadata.items():
+        for worker, metadata in list(self._workers_metadata.items()):
             hostname = worker
             worker_name, _ = get_worker_names(hostname)
             queue_name = (
@@ -148,7 +147,7 @@ class Roquefort:
                     name="worker_active",
                     value=hostname,
                 )
-                workers_to_remove.append(worker)
+                del self._workers_metadata[worker]
                 continue
 
             if (
@@ -166,9 +165,6 @@ class Roquefort:
                     },
                 )
                 continue
-
-        for worker in workers_to_remove:
-            del self._workers_metadata[worker]
 
     def _purger_loop(self):
         """Loop for purging metrics."""

--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -147,6 +147,42 @@ class Roquefort:
                     name="worker_active",
                     value=hostname,
                 )
+                self._metrics.remove_gauge_by_label_value(
+                    name="worker_tasks_active",
+                    value=hostname,
+                )
+                self._metrics.remove_counter_by_label_value(
+                    name="task_sent",
+                    value=hostname,
+                )
+                self._metrics.remove_counter_by_label_value(
+                    name="task_received",
+                    value=hostname,
+                )
+                self._metrics.remove_counter_by_label_value(
+                    name="task_started",
+                    value=hostname,
+                )
+                self._metrics.remove_counter_by_label_value(
+                    name="task_succeeded",
+                    value=hostname,
+                )
+                self._metrics.remove_counter_by_label_value(
+                    name="task_failed",
+                    value=hostname,
+                )
+                self._metrics.remove_counter_by_label_value(
+                    name="task_retried",
+                    value=hostname,
+                )
+                self._metrics.remove_counter_by_label_value(
+                    name="task_rejected",
+                    value=hostname,
+                )
+                self._metrics.remove_counter_by_label_value(
+                    name="task_revoked",
+                    value=hostname,
+                )
                 del self._workers_metadata[worker]
                 continue
 


### PR DESCRIPTION
This pull request refactors the metric removal logic and updates the `_purger` method to streamline the removal of inactive worker metrics. The most important changes include the introduction of a private helper method for metric removal, the addition of new methods for removing counters and histograms by label value, and the simplification of the `_purger` method.

### Refactoring Metric Removal Logic:

* **Private helper method for metric removal**: Introduced `_remove_metric_by_label_value` in `src/metrics/metrics.py` to centralize the logic for removing metrics by label value across different metric types (`gauges`, `counters`, and `histograms`). This reduces code duplication.
* **New methods for counters and histograms**: Added `remove_counter_by_label_value` and `remove_histogram_by_label_value` methods in `src/metrics/metrics.py`, leveraging the new helper method to extend functionality for additional metric types.

### Updates to `_purger` Method:

* **Streamlined worker metric cleanup**: Updated `_purger` in `src/roquefort.py` to use the newly added metric removal methods (`remove_gauge_by_label_value`, `remove_counter_by_label_value`) for cleaning up metrics associated with inactive workers. This eliminates the need for manually tracking workers to remove. [[1]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L151-R186) [[2]](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L170-L172)
* **Improved iteration over worker metadata**: Changed the iteration in `_purger` to use `list(self._workers_metadata.items())` for safer manipulation of the dictionary during iteration.