### PR TITLE
feat(Roquefort): remove hostname label from metrics counters

### DIFF
--- a/src/roquefort.py
+++ b/src/roquefort.py
@@ -58,7 +58,7 @@ class Roquefort:
         self._metrics.create_counter(
             "task_sent",
             "Sent when a task message is published.",
-            labels=["name", "hostname", "queue_name"],
+            labels=["name", "queue_name"],
         )
         self._metrics.create_counter(
             "task_received",
@@ -402,7 +402,6 @@ class Roquefort:
             
         labels = {
             "name": event.get("name"),
-            "hostname": event.get("hostname"),
             "queue_name": queue_name,
         }
 


### PR DESCRIPTION
- Updated the metrics counter for task messages to eliminate the hostname label, simplifying the metrics structure.
- Adjusted the event handling logic to reflect the removal of the hostname label, ensuring consistency in metrics tracking.

This pull request simplifies the metrics tracking in `src/roquefort.py` by removing the `hostname` label from counters related to task events. This change reduces complexity and ensures consistency in the tracked labels.

Changes to metrics tracking:

* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L61-R61): Updated the `task_sent` counter to remove the `hostname` label from its configuration.
* [`src/roquefort.py`](diffhunk://#diff-d57a3ba85ee1d33d1f1b3b74e58e8118cd193e8ee42c553f288a43c39c32fae0L405): Modified the `_handle_task_sent` method to exclude the `hostname` label when constructing the labels dictionary for task events.