### PR TITLE
fix(roquefort.py): adds name label to some metrics

### DIFF
--- a/src/celery_roquefort/roquefort.py
+++ b/src/celery_roquefort/roquefort.py
@@ -448,11 +448,13 @@ class Roquefort:
             return
         
         worker_name, _ = get_worker_names(hostname)
+        task_name = event.get("name")
     
         self._handle_task_generic(
             event=event,
             metric_name="task_started",
             labels={
+                "name": task_name,
                 "worker": worker_name,
                 "hostname": hostname,
                 "queue_name": queue_name,
@@ -472,12 +474,14 @@ class Roquefort:
             return
         
         worker_name, _ = get_worker_names(hostname)
+        task_name = event.get("name")
         runtime = event.get("runtime")
 
         self._handle_task_generic(
             event=event,
             metric_name="task_succeeded",
             labels={
+                "name": task_name,
                 "worker": worker_name,
                 "hostname": hostname,
                 "queue_name": queue_name,


### PR DESCRIPTION
This pull request updates the `src/celery_roquefort/roquefort.py` file to enhance task event handling by adding the `task_name` field to the labels for metrics. This change improves the granularity of metrics by including the specific task name in both `task_started` and `task_succeeded` events.

Enhancements to task event handling:

* [`src/celery_roquefort/roquefort.py`](diffhunk://#diff-919230604f672fc9e21010c49b06f475f03c1f560e721ace98da38317fcdd5efR451-R457): Added the `task_name` field to the labels in the `_handle_task_started` method, allowing metrics to include the specific task name.
* [`src/celery_roquefort/roquefort.py`](diffhunk://#diff-919230604f672fc9e21010c49b06f475f03c1f560e721ace98da38317fcdd5efR477-R484): Added the `task_name` field to the labels in the `_handle_task_succeeded` method, enabling better identification of tasks in metrics.